### PR TITLE
Add ContrastOptimizer with WCAG 2.1 contrast support

### DIFF
--- a/src/core/contrast/ContrastOptimizer.test.ts
+++ b/src/core/contrast/ContrastOptimizer.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContrastOptimizer } from './ContrastOptimizer';
+import { WCAG_CONTRAST_RATIOS, CONTRAST_THRESHOLDS } from './wcag-standards';
+
+describe('ContrastOptimizer', () => {
+  let optimizer: ContrastOptimizer;
+
+  beforeEach(() => {
+    optimizer = new ContrastOptimizer();
+  });
+
+  describe('constructor', () => {
+    it('should create instance with default options', () => {
+      expect(optimizer).toBeInstanceOf(ContrastOptimizer);
+    });
+
+    it('should accept custom options', () => {
+      const customOptimizer = new ContrastOptimizer({
+        level: 'AAA',
+        textSize: 'large',
+        maxIterations: 10,
+        tolerance: 0.05,
+      });
+      expect(customOptimizer.getTargetRatio()).toBe(WCAG_CONTRAST_RATIOS.AAA.large);
+    });
+
+    it('should default to AA level', () => {
+      expect(optimizer.getTargetRatio()).toBe(WCAG_CONTRAST_RATIOS.AA.normal);
+    });
+  });
+
+  describe('getRelativeLuminance', () => {
+    it('should return 0 for pure black', () => {
+      const luminance = optimizer.getRelativeLuminance('000000');
+      expect(luminance).toBeCloseTo(0, 5);
+    });
+
+    it('should return 1 for pure white', () => {
+      const luminance = optimizer.getRelativeLuminance('ffffff');
+      expect(luminance).toBeCloseTo(1, 5);
+    });
+
+    it('should handle # prefix', () => {
+      const luminance = optimizer.getRelativeLuminance('#ffffff');
+      expect(luminance).toBeCloseTo(1, 5);
+    });
+
+    it('should return ~0.2126 for pure red', () => {
+      const luminance = optimizer.getRelativeLuminance('ff0000');
+      expect(luminance).toBeCloseTo(0.2126, 4);
+    });
+
+    it('should return ~0.7152 for pure green', () => {
+      const luminance = optimizer.getRelativeLuminance('00ff00');
+      expect(luminance).toBeCloseTo(0.7152, 4);
+    });
+
+    it('should return ~0.0722 for pure blue', () => {
+      const luminance = optimizer.getRelativeLuminance('0000ff');
+      expect(luminance).toBeCloseTo(0.0722, 4);
+    });
+
+    it('should calculate correct luminance for gray', () => {
+      // Mid-gray (128, 128, 128) should be around 0.215
+      const luminance = optimizer.getRelativeLuminance('808080');
+      expect(luminance).toBeGreaterThan(0.1);
+      expect(luminance).toBeLessThan(0.3);
+    });
+  });
+
+  describe('calculateContrastRatio', () => {
+    it('should return 21:1 for black on white', () => {
+      const ratio = optimizer.calculateContrastRatio('000000', 'ffffff');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+
+    it('should return 21:1 for white on black', () => {
+      const ratio = optimizer.calculateContrastRatio('ffffff', '000000');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+
+    it('should return 1:1 for same colors', () => {
+      const ratio = optimizer.calculateContrastRatio('ff5500', 'ff5500');
+      expect(ratio).toBeCloseTo(1, 5);
+    });
+
+    it('should handle # prefixes', () => {
+      const ratio = optimizer.calculateContrastRatio('#000000', '#ffffff');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+
+    it('should be symmetrical (order independent)', () => {
+      const ratio1 = optimizer.calculateContrastRatio('336699', 'ffffff');
+      const ratio2 = optimizer.calculateContrastRatio('ffffff', '336699');
+      expect(ratio1).toBeCloseTo(ratio2, 5);
+    });
+
+    it('should calculate typical gray on white contrast', () => {
+      // Gray (#767676) is the minimum for AA on white
+      const ratio = optimizer.calculateContrastRatio('767676', 'ffffff');
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it('should calculate low contrast correctly', () => {
+      // Light gray on white should have low contrast
+      const ratio = optimizer.calculateContrastRatio('cccccc', 'ffffff');
+      expect(ratio).toBeLessThan(2);
+    });
+  });
+
+  describe('meetsStandard', () => {
+    it('should return true for black on white (all standards)', () => {
+      expect(optimizer.meetsStandard('000000', 'ffffff', 'AA', 'normal')).toBe(true);
+      expect(optimizer.meetsStandard('000000', 'ffffff', 'AA', 'large')).toBe(true);
+      expect(optimizer.meetsStandard('000000', 'ffffff', 'AAA', 'normal')).toBe(true);
+      expect(optimizer.meetsStandard('000000', 'ffffff', 'AAA', 'large')).toBe(true);
+    });
+
+    it('should return false for same color', () => {
+      expect(optimizer.meetsStandard('ffffff', 'ffffff', 'AA', 'normal')).toBe(false);
+    });
+
+    it('should correctly identify AA compliance', () => {
+      // #767676 on white is exactly 4.54:1 (passes AA normal)
+      expect(optimizer.meetsStandard('767676', 'ffffff', 'AA', 'normal')).toBe(true);
+      // #777777 on white is about 4.48:1 (fails AA normal)
+      expect(optimizer.meetsStandard('787878', 'ffffff', 'AA', 'normal')).toBe(false);
+    });
+
+    it('should correctly identify AAA compliance', () => {
+      // #595959 on white is about 7:1 (passes AAA)
+      expect(optimizer.meetsStandard('595959', 'ffffff', 'AAA', 'normal')).toBe(true);
+    });
+
+    it('should use instance defaults when not specified', () => {
+      const aaOptimizer = new ContrastOptimizer({ level: 'AA', textSize: 'normal' });
+      expect(aaOptimizer.meetsStandard('767676', 'ffffff')).toBe(true);
+    });
+  });
+
+  describe('ensureContrast', () => {
+    it('should not adjust when contrast already meets target', () => {
+      const result = optimizer.ensureContrast('000000', 'ffffff');
+      expect(result.wasAdjusted).toBe(false);
+      expect(result.meetsTarget).toBe(true);
+      expect(result.iterations).toBe(0);
+    });
+
+    it('should adjust low contrast colors to meet AA', () => {
+      // Light gray on white (low contrast)
+      const result = optimizer.ensureContrast('cccccc', 'ffffff');
+      expect(result.wasAdjusted).toBe(true);
+      expect(result.finalRatio).toBeGreaterThanOrEqual(4.5 - 0.01);
+    });
+
+    it('should adjust to meet AAA when configured', () => {
+      const aaaOptimizer = new ContrastOptimizer({ level: 'AAA' });
+      const result = aaaOptimizer.ensureContrast('999999', 'ffffff');
+      expect(result.wasAdjusted).toBe(true);
+      expect(result.finalRatio).toBeGreaterThanOrEqual(7 - 0.01);
+    });
+
+    it('should converge in less than 20 iterations', () => {
+      const result = optimizer.ensureContrast('aaaaaa', 'ffffff');
+      expect(result.iterations).toBeLessThan(20);
+    });
+
+    it('should preserve hue when adjusting', () => {
+      // Blue on white
+      const original = '6699cc';
+      const result = optimizer.ensureContrast(original, 'ffffff');
+
+      if (result.wasAdjusted) {
+        const originalHsl = optimizer.hexToHsl(original);
+        const adjustedHsl = optimizer.hexToHsl(result.adjustedForeground);
+
+        // Hue should be preserved (within rounding tolerance)
+        expect(Math.abs(originalHsl.h - adjustedHsl.h)).toBeLessThanOrEqual(2);
+      }
+    });
+
+    it('should darken colors on light backgrounds', () => {
+      const result = optimizer.ensureContrast('aaaaaa', 'ffffff');
+
+      if (result.wasAdjusted) {
+        const originalLuminance = optimizer.getRelativeLuminance(result.originalForeground);
+        const adjustedLuminance = optimizer.getRelativeLuminance(result.adjustedForeground);
+        expect(adjustedLuminance).toBeLessThan(originalLuminance);
+      }
+    });
+
+    it('should lighten colors on dark backgrounds', () => {
+      const result = optimizer.ensureContrast('555555', '000000');
+
+      if (result.wasAdjusted) {
+        const originalLuminance = optimizer.getRelativeLuminance(result.originalForeground);
+        const adjustedLuminance = optimizer.getRelativeLuminance(result.adjustedForeground);
+        expect(adjustedLuminance).toBeGreaterThan(originalLuminance);
+      }
+    });
+
+    it('should accept custom target ratio', () => {
+      const result = optimizer.ensureContrast('888888', 'ffffff', 3.0);
+      expect(result.targetRatio).toBe(3.0);
+      expect(result.finalRatio).toBeGreaterThanOrEqual(3.0 - 0.01);
+    });
+
+    it('should return normalized hex colors', () => {
+      const result = optimizer.ensureContrast('#AABBCC', '#FFFFFF');
+      expect(result.originalForeground).toBe('aabbcc');
+      expect(result.background).toBe('ffffff');
+      expect(result.adjustedForeground).toMatch(/^[0-9a-f]{6}$/);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle pure white foreground on white background', () => {
+      const result = optimizer.ensureContrast('ffffff', 'ffffff');
+      expect(result.wasAdjusted).toBe(true);
+      // Should darken to create contrast
+      expect(result.finalRatio).toBeGreaterThan(1);
+    });
+
+    it('should handle pure black foreground on black background', () => {
+      const result = optimizer.ensureContrast('000000', '000000');
+      expect(result.wasAdjusted).toBe(true);
+      // Should lighten to create contrast
+      expect(result.finalRatio).toBeGreaterThan(1);
+    });
+
+    it('should handle grayscale colors', () => {
+      const result = optimizer.ensureContrast('888888', 'dddddd');
+      if (result.wasAdjusted) {
+        // Should still create sufficient contrast
+        expect(result.finalRatio).toBeGreaterThanOrEqual(3);
+      }
+    });
+
+    it('should handle saturated colors', () => {
+      // Bright red on white
+      const result = optimizer.ensureContrast('ff0000', 'ffffff');
+      // Red already has decent contrast on white (~4:1)
+      expect(result.finalRatio).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should handle 3-character hex shorthand', () => {
+      const ratio = optimizer.calculateContrastRatio('fff', '000');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+
+    it('should handle 8-character hex with alpha', () => {
+      // Should strip alpha channel
+      const ratio = optimizer.calculateContrastRatio('ffffffFF', '000000FF');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+
+    it('should handle uppercase hex', () => {
+      const ratio = optimizer.calculateContrastRatio('FFFFFF', '000000');
+      expect(ratio).toBeCloseTo(21, 0);
+    });
+  });
+
+  describe('color conversion', () => {
+    describe('hexToRgb', () => {
+      it('should convert black', () => {
+        const rgb = optimizer.hexToRgb('000000');
+        expect(rgb).toEqual({ r: 0, g: 0, b: 0 });
+      });
+
+      it('should convert white', () => {
+        const rgb = optimizer.hexToRgb('ffffff');
+        expect(rgb).toEqual({ r: 255, g: 255, b: 255 });
+      });
+
+      it('should convert colors correctly', () => {
+        const rgb = optimizer.hexToRgb('ff5500');
+        expect(rgb).toEqual({ r: 255, g: 85, b: 0 });
+      });
+    });
+
+    describe('rgbToHex', () => {
+      it('should convert black', () => {
+        const hex = optimizer.rgbToHex({ r: 0, g: 0, b: 0 });
+        expect(hex).toBe('000000');
+      });
+
+      it('should convert white', () => {
+        const hex = optimizer.rgbToHex({ r: 255, g: 255, b: 255 });
+        expect(hex).toBe('ffffff');
+      });
+
+      it('should pad single digit values', () => {
+        const hex = optimizer.rgbToHex({ r: 1, g: 2, b: 3 });
+        expect(hex).toBe('010203');
+      });
+
+      it('should clamp out of range values', () => {
+        const hex = optimizer.rgbToHex({ r: 300, g: -10, b: 128 });
+        expect(hex).toBe('ff0080');
+      });
+    });
+
+    describe('hexToHsl', () => {
+      it('should convert pure red', () => {
+        const hsl = optimizer.hexToHsl('ff0000');
+        expect(hsl.h).toBe(0);
+        expect(hsl.s).toBe(100);
+        expect(hsl.l).toBe(50);
+      });
+
+      it('should convert pure green', () => {
+        const hsl = optimizer.hexToHsl('00ff00');
+        expect(hsl.h).toBe(120);
+        expect(hsl.s).toBe(100);
+        expect(hsl.l).toBe(50);
+      });
+
+      it('should convert pure blue', () => {
+        const hsl = optimizer.hexToHsl('0000ff');
+        expect(hsl.h).toBe(240);
+        expect(hsl.s).toBe(100);
+        expect(hsl.l).toBe(50);
+      });
+
+      it('should convert grayscale', () => {
+        const hsl = optimizer.hexToHsl('808080');
+        expect(hsl.s).toBe(0);
+        expect(hsl.l).toBe(50);
+      });
+    });
+
+    describe('hslToHex', () => {
+      it('should convert pure red', () => {
+        const hex = optimizer.hslToHex({ h: 0, s: 100, l: 50 });
+        expect(hex).toBe('ff0000');
+      });
+
+      it('should convert pure green', () => {
+        const hex = optimizer.hslToHex({ h: 120, s: 100, l: 50 });
+        expect(hex).toBe('00ff00');
+      });
+
+      it('should convert pure blue', () => {
+        const hex = optimizer.hslToHex({ h: 240, s: 100, l: 50 });
+        expect(hex).toBe('0000ff');
+      });
+
+      it('should round-trip correctly', () => {
+        // Use a color that converts cleanly
+        const original = 'ff5500';
+        const hsl = optimizer.hexToHsl(original);
+        const roundTripped = optimizer.hslToHex(hsl);
+        expect(roundTripped).toBe(original);
+      });
+    });
+  });
+
+  describe('adjustLightness', () => {
+    it('should increase lightness', () => {
+      const original = '808080';
+      const lighter = optimizer.adjustLightness(original, 20);
+      const originalHsl = optimizer.hexToHsl(original);
+      const lighterHsl = optimizer.hexToHsl(lighter);
+      expect(lighterHsl.l).toBeGreaterThan(originalHsl.l);
+    });
+
+    it('should decrease lightness', () => {
+      const original = '808080';
+      const darker = optimizer.adjustLightness(original, -20);
+      const originalHsl = optimizer.hexToHsl(original);
+      const darkerHsl = optimizer.hexToHsl(darker);
+      expect(darkerHsl.l).toBeLessThan(originalHsl.l);
+    });
+
+    it('should clamp at 0', () => {
+      const result = optimizer.adjustLightness('333333', -100);
+      const hsl = optimizer.hexToHsl(result);
+      expect(hsl.l).toBe(0);
+    });
+
+    it('should clamp at 100', () => {
+      const result = optimizer.adjustLightness('cccccc', 100);
+      const hsl = optimizer.hexToHsl(result);
+      expect(hsl.l).toBe(100);
+    });
+  });
+
+  describe('setLightness', () => {
+    it('should set specific lightness', () => {
+      const result = optimizer.setLightness('ff5500', 75);
+      const hsl = optimizer.hexToHsl(result);
+      expect(hsl.l).toBe(75);
+    });
+
+    it('should preserve hue', () => {
+      const original = 'ff5500';
+      const originalHsl = optimizer.hexToHsl(original);
+      const result = optimizer.setLightness(original, 30);
+      const resultHsl = optimizer.hexToHsl(result);
+      expect(resultHsl.h).toBe(originalHsl.h);
+    });
+
+    it('should preserve saturation', () => {
+      const original = 'ff5500';
+      const originalHsl = optimizer.hexToHsl(original);
+      const result = optimizer.setLightness(original, 30);
+      const resultHsl = optimizer.hexToHsl(result);
+      expect(resultHsl.s).toBe(originalHsl.s);
+    });
+  });
+
+  describe('getTargetRatio', () => {
+    it('should return AA normal by default', () => {
+      expect(optimizer.getTargetRatio()).toBe(4.5);
+    });
+
+    it('should return AA large when configured', () => {
+      const opt = new ContrastOptimizer({ textSize: 'large' });
+      expect(opt.getTargetRatio()).toBe(3.0);
+    });
+
+    it('should return AAA normal when configured', () => {
+      const opt = new ContrastOptimizer({ level: 'AAA' });
+      expect(opt.getTargetRatio()).toBe(7.0);
+    });
+
+    it('should return AAA large when configured', () => {
+      const opt = new ContrastOptimizer({ level: 'AAA', textSize: 'large' });
+      expect(opt.getTargetRatio()).toBe(4.5);
+    });
+
+    it('should allow override via parameters', () => {
+      expect(optimizer.getTargetRatio('AAA', 'normal')).toBe(7.0);
+    });
+  });
+
+  describe('optimizeThemePairs', () => {
+    it('should optimize multiple color pairs', () => {
+      const pairs = [
+        { foreground: 'windowFg', background: 'windowBg' },
+        { foreground: 'menuFg', background: 'menuBg' },
+      ];
+      const theme = {
+        windowFg: 'aaaaaa',
+        windowBg: 'ffffff',
+        menuFg: 'bbbbbb',
+        menuBg: 'eeeeee',
+      };
+
+      const results = optimizer.optimizeThemePairs(pairs, theme);
+
+      expect(results.size).toBe(2);
+      expect(results.get('windowFg')).toBeDefined();
+      expect(results.get('menuFg')).toBeDefined();
+    });
+
+    it('should skip missing properties', () => {
+      const pairs = [{ foreground: 'missing', background: 'windowBg' }];
+      const theme = { windowBg: 'ffffff' };
+
+      const results = optimizer.optimizeThemePairs(pairs, theme);
+
+      expect(results.size).toBe(0);
+    });
+  });
+
+  describe('WCAG standards constants', () => {
+    it('should have correct AA ratios', () => {
+      expect(WCAG_CONTRAST_RATIOS.AA.normal).toBe(4.5);
+      expect(WCAG_CONTRAST_RATIOS.AA.large).toBe(3.0);
+    });
+
+    it('should have correct AAA ratios', () => {
+      expect(WCAG_CONTRAST_RATIOS.AAA.normal).toBe(7.0);
+      expect(WCAG_CONTRAST_RATIOS.AAA.large).toBe(4.5);
+    });
+
+    it('should have correct threshold constants', () => {
+      expect(CONTRAST_THRESHOLDS.MAX_CONTRAST).toBe(21);
+      expect(CONTRAST_THRESHOLDS.MIN_CONTRAST).toBe(1);
+    });
+  });
+
+  describe('preferLighten option', () => {
+    it('should lighten when preferLighten is true on dark background', () => {
+      const opt = new ContrastOptimizer({ preferLighten: true });
+      const result = opt.ensureContrast('444444', '222222');
+
+      if (result.wasAdjusted) {
+        const originalLum = opt.getRelativeLuminance(result.originalForeground);
+        const adjustedLum = opt.getRelativeLuminance(result.adjustedForeground);
+        expect(adjustedLum).toBeGreaterThan(originalLum);
+      }
+    });
+
+    it('should darken when preferLighten is false on light background', () => {
+      const opt = new ContrastOptimizer({ preferLighten: false });
+      const result = opt.ensureContrast('cccccc', 'ffffff');
+
+      if (result.wasAdjusted) {
+        const originalLum = opt.getRelativeLuminance(result.originalForeground);
+        const adjustedLum = opt.getRelativeLuminance(result.adjustedForeground);
+        expect(adjustedLum).toBeLessThan(originalLum);
+      }
+    });
+  });
+});

--- a/src/core/contrast/ContrastOptimizer.ts
+++ b/src/core/contrast/ContrastOptimizer.ts
@@ -1,0 +1,467 @@
+import {
+  type WCAGLevel,
+  type TextSize,
+  type ContrastOptimizerOptions,
+  type ContrastResult,
+  type HSLColor,
+  type RGBColor,
+  WCAG_CONTRAST_RATIOS,
+} from './wcag-standards';
+
+/**
+ * ContrastOptimizer provides WCAG 2.1 compliant contrast ratio calculations
+ * and automatic color adjustment to ensure text readability.
+ *
+ * Features:
+ * - Calculate contrast ratios per WCAG 2.1 formula
+ * - Adjust colors to meet AA (4.5:1) or AAA (7:1) standards
+ * - Preserve hue while adjusting lightness
+ * - Binary search for efficient convergence (<20 iterations)
+ *
+ * @example
+ * ```typescript
+ * const optimizer = new ContrastOptimizer({ level: 'AA' });
+ * const ratio = optimizer.calculateContrastRatio('#ffffff', '#000000');
+ * // ratio = 21 (maximum contrast)
+ *
+ * const result = optimizer.ensureContrast('#777777', '#ffffff');
+ * // result.adjustedForeground = adjusted color meeting AA standard
+ * ```
+ */
+export class ContrastOptimizer {
+  private options: Required<Omit<ContrastOptimizerOptions, 'preferLighten'>> & {
+    preferLighten?: boolean;
+  };
+
+  constructor(options: ContrastOptimizerOptions = {}) {
+    this.options = {
+      level: options.level ?? 'AA',
+      textSize: options.textSize ?? 'normal',
+      maxIterations: options.maxIterations ?? 20,
+      tolerance: options.tolerance ?? 0.01,
+      preferLighten: options.preferLighten,
+    };
+  }
+
+  // ============================================================
+  // Public API
+  // ============================================================
+
+  /**
+   * Calculates the WCAG 2.1 contrast ratio between two colors.
+   *
+   * The contrast ratio is calculated as (L1 + 0.05) / (L2 + 0.05)
+   * where L1 is the relative luminance of the lighter color and
+   * L2 is the relative luminance of the darker color.
+   *
+   * @param foreground - Foreground color (hex string with or without #)
+   * @param background - Background color (hex string with or without #)
+   * @returns Contrast ratio from 1:1 to 21:1
+   */
+  calculateContrastRatio(foreground: string, background: string): number {
+    const fgLuminance = this.getRelativeLuminance(foreground);
+    const bgLuminance = this.getRelativeLuminance(background);
+
+    const lighter = Math.max(fgLuminance, bgLuminance);
+    const darker = Math.min(fgLuminance, bgLuminance);
+
+    // WCAG 2.1 contrast ratio formula
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
+  /**
+   * Calculates the relative luminance of a color per WCAG 2.1.
+   *
+   * Relative luminance is the relative brightness of any point in a colorspace,
+   * normalized to 0 for darkest black and 1 for lightest white.
+   *
+   * @param color - Hex color string (with or without #)
+   * @returns Relative luminance value between 0 and 1
+   */
+  getRelativeLuminance(color: string): number {
+    const rgb = this.hexToRgb(color);
+
+    // Convert RGB to sRGB
+    const sR = rgb.r / 255;
+    const sG = rgb.g / 255;
+    const sB = rgb.b / 255;
+
+    // Apply gamma correction
+    const r = sR <= 0.03928 ? sR / 12.92 : Math.pow((sR + 0.055) / 1.055, 2.4);
+    const g = sG <= 0.03928 ? sG / 12.92 : Math.pow((sG + 0.055) / 1.055, 2.4);
+    const b = sB <= 0.03928 ? sB / 12.92 : Math.pow((sB + 0.055) / 1.055, 2.4);
+
+    // Calculate relative luminance using ITU-R BT.709 coefficients
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  /**
+   * Adjusts the foreground color to meet the target contrast ratio,
+   * preserving the original hue while adjusting lightness.
+   *
+   * Uses binary search for efficient convergence (typically <10 iterations).
+   *
+   * @param foreground - Foreground color to adjust (hex string)
+   * @param background - Background color (remains unchanged)
+   * @param targetRatio - Optional custom target ratio (defaults to level/textSize)
+   * @returns ContrastResult with original and adjusted colors
+   */
+  ensureContrast(foreground: string, background: string, targetRatio?: number): ContrastResult {
+    const target = targetRatio ?? this.getTargetRatio();
+    const originalRatio = this.calculateContrastRatio(foreground, background);
+
+    // Already meets target
+    if (originalRatio >= target) {
+      return {
+        originalForeground: this.normalizeHex(foreground),
+        background: this.normalizeHex(background),
+        adjustedForeground: this.normalizeHex(foreground),
+        originalRatio,
+        finalRatio: originalRatio,
+        meetsTarget: true,
+        wasAdjusted: false,
+        iterations: 0,
+        targetRatio: target,
+      };
+    }
+
+    // Determine adjustment direction based on background luminance
+    const bgLuminance = this.getRelativeLuminance(background);
+    const shouldLighten = this.options.preferLighten ?? bgLuminance < 0.5;
+
+    // Perform binary search adjustment
+    const { adjustedColor, finalRatio, iterations } = this.binarySearchAdjust(
+      foreground,
+      background,
+      target,
+      shouldLighten
+    );
+
+    return {
+      originalForeground: this.normalizeHex(foreground),
+      background: this.normalizeHex(background),
+      adjustedForeground: adjustedColor,
+      originalRatio,
+      finalRatio,
+      meetsTarget: finalRatio >= target - this.options.tolerance,
+      wasAdjusted: true,
+      iterations,
+      targetRatio: target,
+    };
+  }
+
+  /**
+   * Checks if a color pair meets the specified WCAG standard.
+   *
+   * @param foreground - Foreground color (hex string)
+   * @param background - Background color (hex string)
+   * @param level - WCAG level to check (defaults to instance level)
+   * @param textSize - Text size category (defaults to instance textSize)
+   * @returns Whether the pair meets the standard
+   */
+  meetsStandard(
+    foreground: string,
+    background: string,
+    level?: WCAGLevel,
+    textSize?: TextSize
+  ): boolean {
+    const ratio = this.calculateContrastRatio(foreground, background);
+    const targetLevel = level ?? this.options.level;
+    const targetSize = textSize ?? this.options.textSize;
+    return ratio >= WCAG_CONTRAST_RATIOS[targetLevel][targetSize];
+  }
+
+  /**
+   * Gets the target contrast ratio based on current options.
+   */
+  getTargetRatio(level?: WCAGLevel, textSize?: TextSize): number {
+    const targetLevel = level ?? this.options.level;
+    const targetSize = textSize ?? this.options.textSize;
+    return WCAG_CONTRAST_RATIOS[targetLevel][targetSize];
+  }
+
+  /**
+   * Optimizes multiple color pairs to meet contrast requirements.
+   *
+   * @param pairs - Array of foreground/background pairs with property mappings
+   * @param themeProperties - Theme properties object to read colors from
+   * @returns Map of property names to adjusted colors
+   */
+  optimizeThemePairs(
+    pairs: Array<{ foreground: string; background: string; name?: string }>,
+    themeProperties: Record<string, string>
+  ): Map<string, ContrastResult> {
+    const results = new Map<string, ContrastResult>();
+
+    for (const pair of pairs) {
+      const fgColor = themeProperties[pair.foreground];
+      const bgColor = themeProperties[pair.background];
+
+      if (fgColor && bgColor) {
+        const result = this.ensureContrast(fgColor, bgColor);
+        results.set(pair.foreground, result);
+      }
+    }
+
+    return results;
+  }
+
+  // ============================================================
+  // Binary Search Implementation
+  // ============================================================
+
+  /**
+   * Performs binary search to find optimal lightness adjustment.
+   */
+  private binarySearchAdjust(
+    foreground: string,
+    background: string,
+    targetRatio: number,
+    shouldLighten: boolean
+  ): { adjustedColor: string; finalRatio: number; iterations: number } {
+    const hsl = this.hexToHsl(foreground);
+    let iterations = 0;
+
+    // Set search bounds for lightness
+    let low: number;
+    let high: number;
+
+    if (shouldLighten) {
+      low = hsl.l;
+      high = 100;
+    } else {
+      low = 0;
+      high = hsl.l;
+    }
+
+    let bestColor = this.hslToHex(hsl);
+    let bestRatio = this.calculateContrastRatio(bestColor, background);
+
+    // Binary search for optimal lightness
+    while (iterations < this.options.maxIterations && high - low > 0.1) {
+      const mid = (low + high) / 2;
+      const testHsl: HSLColor = { h: hsl.h, s: hsl.s, l: mid };
+      const testColor = this.hslToHex(testHsl);
+      const testRatio = this.calculateContrastRatio(testColor, background);
+
+      iterations++;
+
+      // Update best if closer to target
+      if (testRatio >= targetRatio - this.options.tolerance) {
+        bestColor = testColor;
+        bestRatio = testRatio;
+
+        // Try to find a color closer to original
+        if (shouldLighten) {
+          high = mid;
+        } else {
+          low = mid;
+        }
+      } else {
+        // Need more contrast
+        if (shouldLighten) {
+          low = mid;
+        } else {
+          high = mid;
+        }
+      }
+
+      // Early exit if we've met the target
+      if (Math.abs(testRatio - targetRatio) < this.options.tolerance) {
+        bestColor = testColor;
+        bestRatio = testRatio;
+        break;
+      }
+    }
+
+    // If still not meeting target, try extreme values
+    if (bestRatio < targetRatio - this.options.tolerance) {
+      const extremeHsl: HSLColor = { h: hsl.h, s: hsl.s, l: shouldLighten ? 100 : 0 };
+      const extremeColor = this.hslToHex(extremeHsl);
+      const extremeRatio = this.calculateContrastRatio(extremeColor, background);
+
+      if (extremeRatio > bestRatio) {
+        bestColor = extremeColor;
+        bestRatio = extremeRatio;
+      }
+    }
+
+    return {
+      adjustedColor: bestColor,
+      finalRatio: bestRatio,
+      iterations,
+    };
+  }
+
+  // ============================================================
+  // Color Conversion Utilities
+  // ============================================================
+
+  /**
+   * Converts a hex color string to RGB components.
+   */
+  hexToRgb(hex: string): RGBColor {
+    const normalized = this.normalizeHex(hex);
+
+    return {
+      r: parseInt(normalized.slice(0, 2), 16),
+      g: parseInt(normalized.slice(2, 4), 16),
+      b: parseInt(normalized.slice(4, 6), 16),
+    };
+  }
+
+  /**
+   * Converts RGB components to hex string (without #).
+   */
+  rgbToHex(rgb: RGBColor): string {
+    const r = Math.round(Math.max(0, Math.min(255, rgb.r)));
+    const g = Math.round(Math.max(0, Math.min(255, rgb.g)));
+    const b = Math.round(Math.max(0, Math.min(255, rgb.b)));
+
+    return (
+      r.toString(16).padStart(2, '0') +
+      g.toString(16).padStart(2, '0') +
+      b.toString(16).padStart(2, '0')
+    );
+  }
+
+  /**
+   * Converts a hex color to HSL representation.
+   */
+  hexToHsl(hex: string): HSLColor {
+    const rgb = this.hexToRgb(hex);
+    return this.rgbToHsl(rgb);
+  }
+
+  /**
+   * Converts RGB to HSL color space.
+   */
+  rgbToHsl(rgb: RGBColor): HSLColor {
+    const r = rgb.r / 255;
+    const g = rgb.g / 255;
+    const b = rgb.b / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    let h = 0;
+    let s = 0;
+
+    if (max !== min) {
+      const d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+      switch (max) {
+        case r:
+          h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+          break;
+        case g:
+          h = ((b - r) / d + 2) / 6;
+          break;
+        case b:
+          h = ((r - g) / d + 4) / 6;
+          break;
+      }
+    }
+
+    return {
+      h: Math.round(h * 360),
+      s: Math.round(s * 100),
+      l: Math.round(l * 100),
+    };
+  }
+
+  /**
+   * Converts HSL to hex color string (without #).
+   */
+  hslToHex(hsl: HSLColor): string {
+    const rgb = this.hslToRgb(hsl);
+    return this.rgbToHex(rgb);
+  }
+
+  /**
+   * Converts HSL to RGB color space.
+   */
+  hslToRgb(hsl: HSLColor): RGBColor {
+    const h = hsl.h / 360;
+    const s = hsl.s / 100;
+    const l = hsl.l / 100;
+
+    if (s === 0) {
+      const gray = Math.round(l * 255);
+      return { r: gray, g: gray, b: gray };
+    }
+
+    const hue2rgb = (p: number, q: number, t: number): number => {
+      let tNorm = t;
+      if (tNorm < 0) tNorm += 1;
+      if (tNorm > 1) tNorm -= 1;
+      if (tNorm < 1 / 6) return p + (q - p) * 6 * tNorm;
+      if (tNorm < 1 / 2) return q;
+      if (tNorm < 2 / 3) return p + (q - p) * (2 / 3 - tNorm) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+
+    return {
+      r: Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+      g: Math.round(hue2rgb(p, q, h) * 255),
+      b: Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+    };
+  }
+
+  /**
+   * Normalizes a hex color string (removes # prefix, handles shorthand).
+   */
+  normalizeHex(hex: string): string {
+    let normalized = hex.replace(/^#/, '').toLowerCase();
+
+    // Handle shorthand (e.g., "fff" -> "ffffff")
+    if (normalized.length === 3) {
+      normalized = normalized
+        .split('')
+        .map((c) => c + c)
+        .join('');
+    }
+
+    // Remove alpha if present (8-char hex)
+    if (normalized.length === 8) {
+      normalized = normalized.slice(0, 6);
+    }
+
+    return normalized;
+  }
+
+  /**
+   * Adjusts color lightness by a specific amount.
+   *
+   * @param hex - Hex color to adjust
+   * @param amount - Lightness adjustment (-100 to 100)
+   * @returns Adjusted hex color
+   */
+  adjustLightness(hex: string, amount: number): string {
+    const hsl = this.hexToHsl(hex);
+    hsl.l = Math.max(0, Math.min(100, hsl.l + amount));
+    return this.hslToHex(hsl);
+  }
+
+  /**
+   * Creates a color with specific lightness while preserving hue and saturation.
+   *
+   * @param hex - Original color for hue/saturation
+   * @param lightness - Target lightness (0-100)
+   * @returns New hex color
+   */
+  setLightness(hex: string, lightness: number): string {
+    const hsl = this.hexToHsl(hex);
+    hsl.l = Math.max(0, Math.min(100, lightness));
+    return this.hslToHex(hsl);
+  }
+}
+
+/**
+ * Default singleton instance for convenient access.
+ */
+export const contrastOptimizer = new ContrastOptimizer();

--- a/src/core/contrast/index.ts
+++ b/src/core/contrast/index.ts
@@ -1,0 +1,14 @@
+export { ContrastOptimizer, contrastOptimizer } from './ContrastOptimizer';
+
+export {
+  type WCAGLevel,
+  type TextSize,
+  type ContrastOptimizerOptions,
+  type ContrastResult,
+  type HSLColor,
+  type RGBColor,
+  type ColorPair,
+  WCAG_CONTRAST_RATIOS,
+  CONTRAST_THRESHOLDS,
+  TELEGRAM_TEXT_PAIRS,
+} from './wcag-standards';

--- a/src/core/contrast/wcag-standards.ts
+++ b/src/core/contrast/wcag-standards.ts
@@ -1,0 +1,156 @@
+/**
+ * WCAG 2.1 Contrast Ratio Standards
+ * https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+ */
+
+/**
+ * WCAG conformance levels for contrast requirements.
+ */
+export type WCAGLevel = 'AA' | 'AAA';
+
+/**
+ * Text size categories affecting contrast requirements.
+ */
+export type TextSize = 'normal' | 'large';
+
+/**
+ * Minimum contrast ratios per WCAG 2.1 guidelines.
+ * 
+ * Level AA:
+ * - Normal text: 4.5:1
+ * - Large text (18pt+ or 14pt+ bold): 3:1
+ * 
+ * Level AAA:
+ * - Normal text: 7:1
+ * - Large text: 4.5:1
+ */
+export const WCAG_CONTRAST_RATIOS: Record<WCAGLevel, Record<TextSize, number>> = {
+  AA: {
+    normal: 4.5,
+    large: 3.0,
+  },
+  AAA: {
+    normal: 7.0,
+    large: 4.5,
+  },
+};
+
+/**
+ * Common contrast ratio thresholds.
+ */
+export const CONTRAST_THRESHOLDS = {
+  /** Minimum for WCAG AA normal text */
+  AA_NORMAL: 4.5,
+  /** Minimum for WCAG AA large text */
+  AA_LARGE: 3.0,
+  /** Minimum for WCAG AAA normal text */
+  AAA_NORMAL: 7.0,
+  /** Minimum for WCAG AAA large text */
+  AAA_LARGE: 4.5,
+  /** Maximum possible contrast (black/white) */
+  MAX_CONTRAST: 21,
+  /** Minimum possible contrast (same color) */
+  MIN_CONTRAST: 1,
+} as const;
+
+/**
+ * Configuration for the contrast optimizer.
+ */
+export interface ContrastOptimizerOptions {
+  /**
+   * Target WCAG conformance level.
+   * @default 'AA'
+   */
+  level?: WCAGLevel;
+
+  /**
+   * Text size category.
+   * @default 'normal'
+   */
+  textSize?: TextSize;
+
+  /**
+   * Maximum iterations for binary search convergence.
+   * @default 20
+   */
+  maxIterations?: number;
+
+  /**
+   * Tolerance for contrast ratio matching.
+   * @default 0.01
+   */
+  tolerance?: number;
+
+  /**
+   * Whether to prefer lightening over darkening when adjusting.
+   * @default undefined (auto-detect based on background)
+   */
+  preferLighten?: boolean;
+}
+
+/**
+ * Result of a contrast check or adjustment.
+ */
+export interface ContrastResult {
+  /** Original foreground color */
+  originalForeground: string;
+  /** Original background color */
+  background: string;
+  /** Adjusted foreground color (if adjustment was needed) */
+  adjustedForeground: string;
+  /** Contrast ratio before adjustment */
+  originalRatio: number;
+  /** Contrast ratio after adjustment */
+  finalRatio: number;
+  /** Whether the original met the target */
+  meetsTarget: boolean;
+  /** Whether adjustment was performed */
+  wasAdjusted: boolean;
+  /** Number of iterations used (if adjusted) */
+  iterations: number;
+  /** Target contrast ratio */
+  targetRatio: number;
+}
+
+/**
+ * HSL color representation for hue-preserving adjustments.
+ */
+export interface HSLColor {
+  h: number; // 0-360
+  s: number; // 0-100
+  l: number; // 0-100
+}
+
+/**
+ * RGB color representation.
+ */
+export interface RGBColor {
+  r: number; // 0-255
+  g: number; // 0-255
+  b: number; // 0-255
+}
+
+/**
+ * Text-background color pair for contrast checking.
+ */
+export interface ColorPair {
+  foreground: string;
+  background: string;
+  name?: string;
+}
+
+/**
+ * Telegram-specific text-background pairs that should meet contrast requirements.
+ */
+export const TELEGRAM_TEXT_PAIRS: ColorPair[] = [
+  { foreground: 'windowFg', background: 'windowBg', name: 'Window text' },
+  { foreground: 'windowFgActive', background: 'windowBgActive', name: 'Active window text' },
+  { foreground: 'windowSubTextFg', background: 'windowBg', name: 'Subtitle text' },
+  { foreground: 'menuFg', background: 'menuBg', name: 'Menu text' },
+  { foreground: 'historyTextInFg', background: 'msgInBg', name: 'Incoming message text' },
+  { foreground: 'historyTextOutFg', background: 'msgOutBg', name: 'Outgoing message text' },
+  { foreground: 'dialogsNameFg', background: 'dialogsBg', name: 'Dialog name' },
+  { foreground: 'dialogsTextFg', background: 'dialogsBg', name: 'Dialog text' },
+  { foreground: 'activeButtonFg', background: 'activeButtonBg', name: 'Active button text' },
+  { foreground: 'lightButtonFg', background: 'lightButtonBg', name: 'Light button text' },
+];


### PR DESCRIPTION
## 📝 Description
Add `ContrastOptimizer` class implementing WCAG 2.1 contrast ratio calculations and automatic color adjustment to ensure text readability. The optimizer uses binary search to efficiently adjust colors while preserving hue, supporting both AA (4.5:1) and AAA (7:1) accessibility standards.

## 🔗 Related Issue
Closes #10 

## 🎯 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🧪 Testing
Comprehensive unit tests (72 tests) covering all ContrastOptimizer functionality:

**Constructor & Configuration**
- [x] Creates instance with default options
- [x] Accepts custom WCAG level, text size, iterations, tolerance
- [x] Defaults to AA level and normal text size

**Relative Luminance Calculation (`getRelativeLuminance`)**
- [x] Returns 0 for pure black (#000000)
- [x] Returns 1 for pure white (#ffffff)
- [x] Handles # prefix correctly
- [x] Returns ~0.2126 for pure red (ITU-R coefficient)
- [x] Returns ~0.7152 for pure green (ITU-R coefficient)
- [x] Returns ~0.0722 for pure blue (ITU-R coefficient)
- [x] Calculates correct luminance for gray

**Contrast Ratio Calculation (`calculateContrastRatio`)**
- [x] Returns 21:1 for black on white (maximum contrast)
- [x] Returns 21:1 for white on black (symmetrical)
- [x] Returns 1:1 for same colors
- [x] Handles # prefixes
- [x] Is order-independent (symmetrical)
- [x] Calculates typical gray on white contrast
- [x] Calculates low contrast correctly

**WCAG Standards Compliance (`meetsStandard`)**
- [x] Returns true for black on white (all standards)
- [x] Returns false for same color
- [x] Correctly identifies AA compliance (4.5:1)
- [x] Correctly identifies AAA compliance (7:1)
- [x] Uses instance defaults when not specified

**Automatic Contrast Adjustment (`ensureContrast`)**
- [x] Does not adjust when contrast already meets target
- [x] Adjusts low contrast colors to meet AA (4.5:1)
- [x] Adjusts to meet AAA (7:1) when configured
- [x] Converges in less than 20 iterations
- [x] Preserves hue when adjusting
- [x] Darkens colors on light backgrounds
- [x] Lightens colors on dark backgrounds
- [x] Accepts custom target ratio
- [x] Returns normalized hex colors

**Edge Cases**
- [x] Handles pure white foreground on white background
- [x] Handles pure black foreground on black background
- [x] Handles grayscale colors
- [x] Handles saturated colors
- [x] Handles 3-character hex shorthand
- [x] Handles 8-character hex with alpha
- [x] Handles uppercase hex

**Color Conversion Utilities**
- [x] hexToRgb: converts black, white, and colors correctly
- [x] rgbToHex: converts with proper padding and clamping
- [x] hexToHsl: converts primary colors (red, green, blue) and grayscale
- [x] hslToHex: converts primary colors and round-trips correctly
- [x] adjustLightness: increases/decreases and clamps at bounds
- [x] setLightness: sets specific value while preserving hue/saturation

**Target Ratio Configuration**
- [x] Returns AA normal (4.5) by default
- [x] Returns AA large (3.0) when configured
- [x] Returns AAA normal (7.0) when configured
- [x] Returns AAA large (4.5) when configured
- [x] Allows override via parameters

**Theme Integration**
- [x] optimizeThemePairs: optimizes multiple color pairs
- [x] optimizeThemePairs: skips missing properties

**preferLighten Option**
- [x] Lightens when preferLighten is true on dark background
- [x] Darkens when preferLighten is false on light background

**Test Results**:
- 72 new tests for ContrastOptimizer
- 188 total tests passing (27 ColorExtractor + 48 TelegramThemeBuilder + 41 ThemeValidator + 72 ContrastOptimizer)
- ESLint: 0 errors, 0 warnings
- Build: Success

**Test Configuration**:
- Node.js with Vitest 3.2.4
- OS: Windows

## 📸 Screenshots (if applicable)
N/A - Core library functionality

## 📝 Additional Notes
- Binary search algorithm ensures convergence in typically <10 iterations (max 20)
- HSL color space used for hue-preserving adjustments
- Includes `TELEGRAM_TEXT_PAIRS` constant for common Telegram text-background pairs
- Exports singleton `contrastOptimizer` for convenient default usage
- All types exported: `WCAGLevel`, `TextSize`, `ContrastOptimizerOptions`, `ContrastResult`, `HSLColor`, `RGBColor`, `ColorPair`
