### PR TITLE
Add realistic Telegram Desktop theme preview

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './uploader';
 export * from './common';
+export * from './preview';

--- a/src/components/preview/ChatBubble.test.tsx
+++ b/src/components/preview/ChatBubble.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChatBubble } from './ChatBubble';
+import { defaultPreviewTheme, type Message, type PreviewThemeColors } from './types';
+
+describe('ChatBubble', () => {
+  const theme: PreviewThemeColors = defaultPreviewTheme;
+  
+  const createMessage = (overrides: Partial<Message> = {}): Message => ({
+    id: '1',
+    text: 'Hello, world!',
+    direction: 'incoming',
+    timestamp: new Date('2025-01-15T10:30:00'),
+    ...overrides,
+  });
+  
+  describe('rendering', () => {
+    it('should render the chat bubble', () => {
+      render(<ChatBubble message={createMessage()} theme={theme} />);
+      expect(screen.getByTestId('chat-bubble')).toBeInTheDocument();
+    });
+    
+    it('should render the message text', () => {
+      render(<ChatBubble message={createMessage({ text: 'Test message' })} theme={theme} />);
+      expect(screen.getByText('Test message')).toBeInTheDocument();
+    });
+    
+    it('should render the timestamp', () => {
+      render(<ChatBubble message={createMessage()} theme={theme} />);
+      expect(screen.getByTestId('timestamp')).toBeInTheDocument();
+    });
+    
+    it('should apply custom className', () => {
+      render(
+        <ChatBubble
+          message={createMessage()}
+          theme={theme}
+          className="custom-class"
+        />
+      );
+      expect(screen.getByTestId('chat-bubble')).toHaveClass('custom-class');
+    });
+  });
+  
+  describe('message direction', () => {
+    it('should render incoming message aligned left', () => {
+      render(<ChatBubble message={createMessage({ direction: 'incoming' })} theme={theme} />);
+      expect(screen.getByTestId('chat-bubble')).toHaveClass('justify-start');
+    });
+    
+    it('should render outgoing message aligned right', () => {
+      render(<ChatBubble message={createMessage({ direction: 'outgoing' })} theme={theme} />);
+      expect(screen.getByTestId('chat-bubble')).toHaveClass('justify-end');
+    });
+    
+    it('should set data-direction attribute', () => {
+      render(<ChatBubble message={createMessage({ direction: 'outgoing' })} theme={theme} />);
+      expect(screen.getByTestId('chat-bubble')).toHaveAttribute('data-direction', 'outgoing');
+    });
+  });
+  
+  describe('theming', () => {
+    it('should apply incoming message background color', () => {
+      render(<ChatBubble message={createMessage({ direction: 'incoming' })} theme={theme} />);
+      const bubble = screen.getByTestId('chat-bubble').querySelector('div');
+      expect(bubble).toHaveStyle({ backgroundColor: '#ffffff' });
+    });
+    
+    it('should apply outgoing message background color', () => {
+      render(<ChatBubble message={createMessage({ direction: 'outgoing' })} theme={theme} />);
+      const bubble = screen.getByTestId('chat-bubble').querySelector('div');
+      expect(bubble).toHaveStyle({ backgroundColor: '#efffde' });
+    });
+  });
+  
+  describe('read status', () => {
+    it('should show sent status icon for outgoing messages', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ direction: 'outgoing', readStatus: 'sent' })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('status-sent')).toBeInTheDocument();
+    });
+    
+    it('should show delivered status icon', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ direction: 'outgoing', readStatus: 'delivered' })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('status-delivered')).toBeInTheDocument();
+    });
+    
+    it('should show read status icon', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ direction: 'outgoing', readStatus: 'read' })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('status-read')).toBeInTheDocument();
+    });
+    
+    it('should not show status for incoming messages', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ direction: 'incoming', readStatus: 'read' })}
+          theme={theme}
+        />
+      );
+      expect(screen.queryByTestId('status-read')).not.toBeInTheDocument();
+    });
+  });
+  
+  describe('sender name', () => {
+    it('should show sender name when showSenderName is true', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ senderName: 'Alice' })}
+          theme={theme}
+          showSenderName={true}
+        />
+      );
+      expect(screen.getByTestId('sender-name')).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    
+    it('should not show sender name for outgoing messages', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ direction: 'outgoing', senderName: 'Me' })}
+          theme={theme}
+          showSenderName={true}
+        />
+      );
+      expect(screen.queryByTestId('sender-name')).not.toBeInTheDocument();
+    });
+    
+    it('should not show sender name when showSenderName is false', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ senderName: 'Alice' })}
+          theme={theme}
+          showSenderName={false}
+        />
+      );
+      expect(screen.queryByTestId('sender-name')).not.toBeInTheDocument();
+    });
+  });
+  
+  describe('reply preview', () => {
+    it('should show reply preview when message has replyTo', () => {
+      render(
+        <ChatBubble
+          message={createMessage({
+            replyTo: { senderName: 'Bob', text: 'Original message' },
+          })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('reply-preview')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText('Original message')).toBeInTheDocument();
+    });
+    
+    it('should not show reply preview when no replyTo', () => {
+      render(<ChatBubble message={createMessage()} theme={theme} />);
+      expect(screen.queryByTestId('reply-preview')).not.toBeInTheDocument();
+    });
+  });
+  
+  describe('service messages', () => {
+    it('should render service message differently', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ isService: true, text: 'User joined the group' })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('service-message')).toBeInTheDocument();
+      expect(screen.getByText('User joined the group')).toBeInTheDocument();
+    });
+    
+    it('should center service messages', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ isService: true })}
+          theme={theme}
+        />
+      );
+      expect(screen.getByTestId('service-message')).toHaveClass('justify-center');
+    });
+  });
+  
+  describe('whitespace handling', () => {
+    it('should preserve whitespace in messages', () => {
+      render(
+        <ChatBubble
+          message={createMessage({ text: 'Line 1\nLine 2' })}
+          theme={theme}
+        />
+      );
+      const text = screen.getByText(/Line 1/);
+      expect(text).toHaveClass('whitespace-pre-wrap');
+    });
+    
+    it('should break long words', () => {
+      render(
+        <ChatBubble
+          message={createMessage()}
+          theme={theme}
+        />
+      );
+      const text = screen.getByText('Hello, world!');
+      expect(text).toHaveClass('break-words');
+    });
+  });
+});

--- a/src/components/preview/ChatBubble.tsx
+++ b/src/components/preview/ChatBubble.tsx
@@ -1,0 +1,266 @@
+import { useMemo } from 'react';
+import type { ChatBubbleProps, ReadStatus } from './types';
+import { hexToCSS } from './types';
+
+/**
+ * Formats a timestamp for display in a chat bubble
+ */
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).toLowerCase();
+}
+
+/**
+ * Read status indicator icons
+ */
+function ReadStatusIcon({ status, color }: { status: ReadStatus; color: string }) {
+  const iconStyle = { color: hexToCSS(color) };
+  
+  switch (status) {
+    case 'sent':
+      return (
+        <svg
+          data-testid="status-sent"
+          className="w-4 h-4 flex-shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          style={iconStyle}
+        >
+          <path
+            d="M4 8l3 3 5-6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'delivered':
+      return (
+        <svg
+          data-testid="status-delivered"
+          className="w-4 h-4 flex-shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          style={iconStyle}
+        >
+          <path
+            d="M2 8l3 3 5-6M6 8l3 3 5-6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'read':
+      return (
+        <svg
+          data-testid="status-read"
+          className="w-4 h-4 flex-shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          style={iconStyle}
+        >
+          <path
+            d="M2 8l3 3 5-6M6 8l3 3 5-6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * Reply preview inside a message bubble
+ */
+function ReplyPreview({
+  senderName,
+  text,
+  barColor,
+  textColor,
+}: {
+  senderName: string;
+  text: string;
+  barColor: string;
+  textColor: string;
+}) {
+  return (
+    <div
+      data-testid="reply-preview"
+      className="flex items-stretch mb-1.5 rounded overflow-hidden"
+    >
+      <div
+        className="w-0.5 flex-shrink-0"
+        style={{ backgroundColor: hexToCSS(barColor) }}
+      />
+      <div className="pl-2 py-0.5 min-w-0">
+        <div
+          className="text-xs font-medium truncate"
+          style={{ color: hexToCSS(barColor) }}
+        >
+          {senderName}
+        </div>
+        <div
+          className="text-xs truncate opacity-70"
+          style={{ color: hexToCSS(textColor) }}
+        >
+          {text}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ChatBubble component
+ * 
+ * Renders a single message bubble styled according to the provided theme.
+ * Supports incoming and outgoing messages, replies, timestamps, and read indicators.
+ */
+export function ChatBubble({
+  message,
+  theme,
+  showSenderName = false,
+  className = '',
+}: Omit<ChatBubbleProps, 'isGroupChat'>) {
+  const isOutgoing = message.direction === 'outgoing';
+  const isService = message.isService;
+  
+  // Memoize computed styles for performance
+  const styles = useMemo(() => {
+    if (isService) {
+      return {
+        background: hexToCSS(theme.msgServiceBg),
+        color: hexToCSS(theme.msgServiceFg),
+      };
+    }
+    
+    return {
+      background: isOutgoing
+        ? hexToCSS(theme.msgOutBg)
+        : hexToCSS(theme.msgInBg),
+      color: isOutgoing
+        ? hexToCSS(theme.historyTextOutFg)
+        : hexToCSS(theme.historyTextInFg),
+      dateColor: isOutgoing
+        ? hexToCSS(theme.msgOutDateFg)
+        : hexToCSS(theme.msgInDateFg),
+      replyBarColor: isOutgoing
+        ? theme.msgOutReplyBarColor
+        : theme.msgInReplyBarColor,
+      statusColor: theme.historyOutIconFg,
+    };
+  }, [theme, isOutgoing, isService]);
+  
+  // Determine sender name color for group chats (must be before any return)
+  const senderNameColor = useMemo(() => {
+    if (!showSenderName || !message.senderName || isOutgoing) return null;
+    
+    // Use different peer colors based on sender name hash
+    const hash = message.senderName.split('').reduce(
+      (acc, char) => acc + char.charCodeAt(0),
+      0
+    );
+    const peerColors = [
+      theme.historyPeer1NameFg,
+      theme.historyPeer2NameFg,
+      theme.historyPeer3NameFg,
+      theme.historyPeer4NameFg,
+    ];
+    return peerColors[hash % peerColors.length];
+  }, [theme, showSenderName, message.senderName, isOutgoing]);
+  
+  // Service messages (date separators, etc.)
+  if (isService) {
+    return (
+      <div
+        data-testid="service-message"
+        className={`flex justify-center my-2 ${className}`}
+      >
+        <div
+          className="px-3 py-1 rounded-full text-xs font-medium"
+          style={{
+            backgroundColor: styles.background,
+            color: styles.color,
+          }}
+        >
+          {message.text}
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div
+      data-testid="chat-bubble"
+      data-direction={message.direction}
+      className={`flex ${isOutgoing ? 'justify-end' : 'justify-start'} mb-1 ${className}`}
+    >
+      <div
+        className={`
+          relative max-w-[80%] px-3 py-1.5 rounded-lg
+          ${isOutgoing ? 'rounded-br-sm' : 'rounded-bl-sm'}
+        `}
+        style={{
+          backgroundColor: styles.background,
+          color: styles.color,
+        }}
+      >
+        {/* Sender name for group chats */}
+        {showSenderName && senderNameColor && !isOutgoing && (
+          <div
+            data-testid="sender-name"
+            className="text-xs font-semibold mb-0.5"
+            style={{ color: hexToCSS(senderNameColor) }}
+          >
+            {message.senderName}
+          </div>
+        )}
+        
+        {/* Reply preview */}
+        {message.replyTo && (
+          <ReplyPreview
+            senderName={message.replyTo.senderName}
+            text={message.replyTo.text}
+            barColor={styles.replyBarColor!}
+            textColor={styles.color}
+          />
+        )}
+        
+        {/* Message text */}
+        <div className="text-sm leading-relaxed whitespace-pre-wrap break-words">
+          {message.text}
+        </div>
+        
+        {/* Timestamp and read status */}
+        <div className="flex items-center justify-end gap-1 mt-0.5 -mb-0.5">
+          <span
+            data-testid="timestamp"
+            className="text-[10px] leading-none"
+            style={{ color: styles.dateColor }}
+          >
+            {formatTime(message.timestamp)}
+          </span>
+          
+          {isOutgoing && message.readStatus && (
+            <ReadStatusIcon
+              status={message.readStatus}
+              color={styles.statusColor!}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ChatBubble;

--- a/src/components/preview/MessageList.test.tsx
+++ b/src/components/preview/MessageList.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageList, TypingIndicator } from './MessageList';
+import { defaultPreviewTheme, type Message, type PreviewThemeColors } from './types';
+
+describe('MessageList', () => {
+  const theme: PreviewThemeColors = defaultPreviewTheme;
+  
+  const createMessages = (count: number): Message[] => {
+    const messages: Message[] = [];
+    const now = new Date();
+    
+    for (let i = 0; i < count; i++) {
+      messages.push({
+        id: String(i + 1),
+        text: `Message ${i + 1}`,
+        direction: i % 2 === 0 ? 'incoming' : 'outgoing',
+        timestamp: new Date(now.getTime() - (count - i) * 60000),
+        senderName: i % 2 === 0 ? 'Alice' : undefined,
+        readStatus: i % 2 === 1 ? 'read' : undefined,
+      });
+    }
+    
+    return messages;
+  };
+  
+  describe('rendering', () => {
+    it('should render the message list', () => {
+      render(<MessageList messages={[]} theme={theme} />);
+      expect(screen.getByTestId('message-list')).toBeInTheDocument();
+    });
+    
+    it('should render all messages', () => {
+      render(<MessageList messages={createMessages(5)} theme={theme} />);
+      expect(screen.getByText('Message 1')).toBeInTheDocument();
+      expect(screen.getByText('Message 2')).toBeInTheDocument();
+      expect(screen.getByText('Message 3')).toBeInTheDocument();
+      expect(screen.getByText('Message 4')).toBeInTheDocument();
+      expect(screen.getByText('Message 5')).toBeInTheDocument();
+    });
+    
+    it('should apply custom className', () => {
+      render(
+        <MessageList
+          messages={[]}
+          theme={theme}
+          className="custom-class"
+        />
+      );
+      expect(screen.getByTestId('message-list')).toHaveClass('custom-class');
+    });
+    
+    it('should apply background color from theme', () => {
+      render(<MessageList messages={[]} theme={theme} />);
+      expect(screen.getByTestId('message-list')).toHaveStyle({
+        backgroundColor: '#ffffff',
+      });
+    });
+  });
+  
+  describe('date separators', () => {
+    it('should render date separator', () => {
+      render(<MessageList messages={createMessages(1)} theme={theme} />);
+      expect(screen.getByTestId('date-separator')).toBeInTheDocument();
+    });
+    
+    it('should show "Today" for today\'s messages', () => {
+      render(<MessageList messages={createMessages(1)} theme={theme} />);
+      expect(screen.getByText('Today')).toBeInTheDocument();
+    });
+    
+    it('should group messages by date', () => {
+      const messages: Message[] = [
+        {
+          id: '1',
+          text: 'Yesterday message',
+          direction: 'incoming',
+          timestamp: new Date(Date.now() - 86400000 * 2),
+        },
+        {
+          id: '2',
+          text: 'Today message',
+          direction: 'outgoing',
+          timestamp: new Date(),
+        },
+      ];
+      
+      render(<MessageList messages={messages} theme={theme} />);
+      const groups = screen.getAllByTestId('message-group');
+      expect(groups.length).toBe(2);
+    });
+  });
+  
+  describe('group chat mode', () => {
+    it('should show sender names in group chat', () => {
+      const messages: Message[] = [
+        {
+          id: '1',
+          text: 'Hello from Alice',
+          direction: 'incoming',
+          timestamp: new Date(),
+          senderName: 'Alice',
+        },
+      ];
+      
+      render(<MessageList messages={messages} theme={theme} isGroupChat={true} />);
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+    
+    it('should not show sender names when not in group chat', () => {
+      const messages: Message[] = [
+        {
+          id: '1',
+          text: 'Hello from Alice',
+          direction: 'incoming',
+          timestamp: new Date(),
+          senderName: 'Alice',
+        },
+      ];
+      
+      render(<MessageList messages={messages} theme={theme} isGroupChat={false} />);
+      // Should not show sender name in container
+      expect(screen.queryByTestId('sender-name')).not.toBeInTheDocument();
+    });
+  });
+  
+  describe('empty state', () => {
+    it('should render empty list without errors', () => {
+      render(<MessageList messages={[]} theme={theme} />);
+      expect(screen.getByTestId('message-list')).toBeInTheDocument();
+      expect(screen.queryByTestId('chat-bubble')).not.toBeInTheDocument();
+    });
+  });
+  
+  describe('scrolling', () => {
+    it('should be scrollable', () => {
+      render(<MessageList messages={createMessages(10)} theme={theme} />);
+      expect(screen.getByTestId('message-list')).toHaveClass('overflow-y-auto');
+    });
+  });
+});
+
+describe('TypingIndicator', () => {
+  const theme = defaultPreviewTheme;
+  
+  it('should render typing indicator', () => {
+    render(
+      <TypingIndicator
+        bgColor={theme.msgInBg}
+        dotColor={theme.dialogsTextFg}
+      />
+    );
+    expect(screen.getByTestId('typing-indicator')).toBeInTheDocument();
+  });
+  
+  it('should render three dots', () => {
+    render(
+      <TypingIndicator
+        bgColor={theme.msgInBg}
+        dotColor={theme.dialogsTextFg}
+      />
+    );
+    const dots = screen.getByTestId('typing-indicator').querySelectorAll('.rounded-full.animate-bounce');
+    expect(dots.length).toBe(3);
+  });
+  
+  it('should apply background color', () => {
+    render(
+      <TypingIndicator
+        bgColor="#ff0000"
+        dotColor={theme.dialogsTextFg}
+      />
+    );
+    const container = screen.getByTestId('typing-indicator').querySelector('div > div');
+    expect(container).toHaveStyle({ backgroundColor: '#ff0000' });
+  });
+});

--- a/src/components/preview/MessageList.tsx
+++ b/src/components/preview/MessageList.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useRef, useEffect } from 'react';
+import { ChatBubble } from './ChatBubble';
+import type { MessageListProps, Message } from './types';
+import { hexToCSS } from './types';
+
+/**
+ * Groups messages by date for rendering date separators
+ */
+function groupMessagesByDate(messages: Message[]): Map<string, Message[]> {
+  const groups = new Map<string, Message[]>();
+  
+  for (const message of messages) {
+    const dateKey = message.timestamp.toDateString();
+    const existing = groups.get(dateKey) || [];
+    existing.push(message);
+    groups.set(dateKey, existing);
+  }
+  
+  return groups;
+}
+
+/**
+ * Formats a date for the date separator
+ */
+function formatDateSeparator(date: Date): string {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  
+  if (date.toDateString() === today.toDateString()) {
+    return 'Today';
+  }
+  
+  if (date.toDateString() === yesterday.toDateString()) {
+    return 'Yesterday';
+  }
+  
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Date separator component
+ */
+function DateSeparator({
+  date,
+  bgColor,
+  textColor,
+}: {
+  date: Date;
+  bgColor: string;
+  textColor: string;
+}) {
+  return (
+    <div
+      data-testid="date-separator"
+      className="flex justify-center my-3"
+    >
+      <div
+        className="px-3 py-1 rounded-full text-xs font-medium"
+        style={{
+          backgroundColor: hexToCSS(bgColor),
+          color: hexToCSS(textColor),
+        }}
+      >
+        {formatDateSeparator(date)}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Typing indicator component
+ */
+export function TypingIndicator({
+  bgColor,
+  dotColor,
+}: {
+  bgColor: string;
+  dotColor: string;
+}) {
+  return (
+    <div
+      data-testid="typing-indicator"
+      className="flex justify-start mb-1"
+    >
+      <div
+        className="px-3 py-2 rounded-lg rounded-bl-sm"
+        style={{ backgroundColor: hexToCSS(bgColor) }}
+      >
+        <div className="flex gap-1">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="w-2 h-2 rounded-full animate-bounce"
+              style={{
+                backgroundColor: hexToCSS(dotColor),
+                animationDelay: `${i * 150}ms`,
+                animationDuration: '600ms',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * MessageList component
+ * 
+ * Renders a scrollable list of messages with date separators.
+ * Automatically scrolls to bottom when new messages arrive.
+ * Supports both individual and group chat modes.
+ */
+export function MessageList({
+  messages,
+  theme,
+  isGroupChat = false,
+  className = '',
+}: MessageListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  
+  // Group messages by date
+  const messageGroups = useMemo(
+    () => groupMessagesByDate(messages),
+    [messages]
+  );
+  
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [messages]);
+  
+  // Scrollbar styles
+  const scrollbarStyles = useMemo(() => ({
+    '--scroll-bg': hexToCSS(theme.scrollBg),
+    '--scroll-bg-over': hexToCSS(theme.scrollBgOver),
+    '--scroll-bar-bg': hexToCSS(theme.scrollBarBg),
+    '--scroll-bar-bg-over': hexToCSS(theme.scrollBarBgOver),
+  }), [theme]);
+  
+  return (
+    <div
+      ref={containerRef}
+      data-testid="message-list"
+      className={`
+        flex-1 overflow-y-auto px-3 py-2
+        scrollbar-thin scrollbar-thumb-rounded
+        ${className}
+      `}
+      style={{
+        backgroundColor: hexToCSS(theme.windowBg),
+        ...scrollbarStyles as React.CSSProperties,
+      }}
+    >
+      {Array.from(messageGroups.entries()).map(([dateKey, dayMessages]) => (
+        <div key={dateKey} data-testid="message-group">
+          <DateSeparator
+            date={new Date(dateKey)}
+            bgColor={theme.msgServiceBg}
+            textColor={theme.msgServiceFg}
+          />
+          
+          {dayMessages.map((message) => (
+            <ChatBubble
+              key={message.id}
+              message={message}
+              theme={theme}
+              showSenderName={isGroupChat && message.direction === 'incoming'}
+              isGroupChat={isGroupChat}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default MessageList;

--- a/src/components/preview/ThemePreview.test.tsx
+++ b/src/components/preview/ThemePreview.test.tsx
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemePreview } from './ThemePreview';
+import { defaultPreviewTheme, type PreviewThemeColors } from './types';
+
+describe('ThemePreview', () => {
+  const theme: PreviewThemeColors = defaultPreviewTheme;
+  
+  describe('rendering', () => {
+    it('should render the theme preview', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('theme-preview')).toBeInTheDocument();
+    });
+    
+    it('should render the title bar', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('title-bar')).toBeInTheDocument();
+    });
+    
+    it('should render the sidebar', () => {
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    });
+    
+    it('should render the chat header', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('chat-header')).toBeInTheDocument();
+    });
+    
+    it('should render the message list', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('message-list')).toBeInTheDocument();
+    });
+    
+    it('should render the compose area', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('compose-area')).toBeInTheDocument();
+    });
+    
+    it('should apply custom className', () => {
+      render(<ThemePreview theme={theme} className="custom-class" />);
+      expect(screen.getByTestId('theme-preview')).toHaveClass('custom-class');
+    });
+  });
+  
+  describe('sidebar', () => {
+    it('should show sidebar when showSidebar is true', () => {
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    });
+    
+    it('should hide sidebar when showSidebar is false', () => {
+      render(<ThemePreview theme={theme} showSidebar={false} />);
+      expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
+    });
+    
+    it('should render chat list items', () => {
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      const chatItems = screen.getAllByTestId('chat-list-item');
+      expect(chatItems.length).toBeGreaterThan(0);
+    });
+    
+    it('should highlight active chat', () => {
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      const chatItems = screen.getAllByTestId('chat-list-item');
+      // First chat should be active by default
+      expect(chatItems[0]).toHaveStyle({
+        backgroundColor: '#419fd9',
+      });
+    });
+  });
+  
+  describe('chat selection', () => {
+    it('should change active chat when clicking chat list item', async () => {
+      const user = userEvent.setup();
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      
+      const chatItems = screen.getAllByTestId('chat-list-item');
+      await user.click(chatItems[1]);
+      
+      // Second chat should now be active
+      await waitFor(() => {
+        expect(chatItems[1]).toHaveStyle({
+          backgroundColor: '#419fd9',
+        });
+      });
+    });
+    
+    it('should show typing indicator after selecting new chat', async () => {
+      const user = userEvent.setup();
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      
+      const chatItems = screen.getAllByTestId('chat-list-item');
+      await user.click(chatItems[1]);
+      
+      await waitFor(() => {
+        expect(screen.getByTestId('typing-indicator')).toBeInTheDocument();
+      });
+    });
+  });
+  
+  describe('theming', () => {
+    it('should apply window background color', () => {
+      const customTheme = {
+        ...theme,
+        windowBg: '#ff0000',
+      };
+      render(<ThemePreview theme={customTheme} />);
+      expect(screen.getByTestId('theme-preview')).toHaveStyle({
+        backgroundColor: '#ff0000',
+      });
+    });
+    
+    it('should apply dialog background color to sidebar', () => {
+      const customTheme = {
+        ...theme,
+        dialogsBg: '#00ff00',
+      };
+      render(<ThemePreview theme={customTheme} showSidebar={true} />);
+      expect(screen.getByTestId('sidebar')).toHaveStyle({
+        backgroundColor: '#00ff00',
+      });
+    });
+    
+    it('should update colors in real-time', () => {
+      const { rerender } = render(<ThemePreview theme={theme} />);
+      
+      expect(screen.getByTestId('theme-preview')).toHaveStyle({
+        backgroundColor: '#ffffff',
+      });
+      
+      const updatedTheme = {
+        ...theme,
+        windowBg: '#0000ff',
+      };
+      rerender(<ThemePreview theme={updatedTheme} />);
+      
+      expect(screen.getByTestId('theme-preview')).toHaveStyle({
+        backgroundColor: '#0000ff',
+      });
+    });
+  });
+  
+  describe('title bar', () => {
+    it('should show Telegram Desktop text', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByText('Telegram Desktop')).toBeInTheDocument();
+    });
+    
+    it('should apply title bar colors', () => {
+      const customTheme = {
+        ...theme,
+        titleBgActive: '#333333',
+      };
+      render(<ThemePreview theme={customTheme} />);
+      expect(screen.getByTestId('title-bar')).toHaveStyle({
+        backgroundColor: '#333333',
+      });
+    });
+  });
+  
+  describe('chat header', () => {
+    it('should show chat name', () => {
+      render(<ThemePreview theme={theme} />);
+      // Chat header should show Alex (also appears in sidebar)
+      const header = screen.getByTestId('chat-header');
+      expect(header).toHaveTextContent('Alex');
+    });
+    
+    it('should show online status', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByText('online')).toBeInTheDocument();
+    });
+  });
+  
+  describe('compose area', () => {
+    it('should show placeholder text', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByText('Write a message...')).toBeInTheDocument();
+    });
+    
+    it('should apply compose area colors', () => {
+      const customTheme = {
+        ...theme,
+        historyComposeAreaBg: '#eeeeee',
+      };
+      render(<ThemePreview theme={customTheme} />);
+      expect(screen.getByTestId('compose-area')).toHaveStyle({
+        backgroundColor: '#eeeeee',
+      });
+    });
+  });
+  
+  describe('responsive design', () => {
+    it('should have max-width when responsive is true', () => {
+      render(<ThemePreview theme={theme} responsive={true} />);
+      expect(screen.getByTestId('theme-preview')).toHaveClass('max-w-4xl');
+    });
+    
+    it('should not have max-width when responsive is false', () => {
+      render(<ThemePreview theme={theme} responsive={false} />);
+      expect(screen.getByTestId('theme-preview')).not.toHaveClass('max-w-4xl');
+    });
+    
+    it('should hide sidebar on mobile when responsive', () => {
+      render(<ThemePreview theme={theme} responsive={true} showSidebar={true} />);
+      // The sidebar container should have hidden class for mobile
+      const sidebarContainer = screen.getByTestId('sidebar').parentElement;
+      expect(sidebarContainer).toHaveClass('hidden');
+      expect(sidebarContainer).toHaveClass('md:block');
+    });
+  });
+  
+  describe('sample messages', () => {
+    it('should render sample messages', () => {
+      render(<ThemePreview theme={theme} />);
+      const chatBubbles = screen.getAllByTestId('chat-bubble');
+      expect(chatBubbles.length).toBeGreaterThan(0);
+    });
+    
+    it('should show both incoming and outgoing messages', () => {
+      render(<ThemePreview theme={theme} />);
+      const chatBubbles = screen.getAllByTestId('chat-bubble');
+      
+      const incomingBubbles = chatBubbles.filter(
+        (bubble) => bubble.getAttribute('data-direction') === 'incoming'
+      );
+      const outgoingBubbles = chatBubbles.filter(
+        (bubble) => bubble.getAttribute('data-direction') === 'outgoing'
+      );
+      
+      expect(incomingBubbles.length).toBeGreaterThan(0);
+      expect(outgoingBubbles.length).toBeGreaterThan(0);
+    });
+  });
+  
+  describe('default theme', () => {
+    it('should use default theme when none provided', () => {
+      render(<ThemePreview />);
+      expect(screen.getByTestId('theme-preview')).toBeInTheDocument();
+    });
+  });
+  
+  describe('unread badges', () => {
+    it('should show unread count badges', () => {
+      render(<ThemePreview theme={theme} showSidebar={true} />);
+      // Should have chats with unread counts in sample data
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('12')).toBeInTheDocument();
+    });
+  });
+  
+  describe('accessibility', () => {
+    it('should have proper structure for screen readers', () => {
+      render(<ThemePreview theme={theme} />);
+      expect(screen.getByTestId('message-list')).toBeInTheDocument();
+      expect(screen.getByTestId('compose-area')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/preview/ThemePreview.tsx
+++ b/src/components/preview/ThemePreview.tsx
@@ -1,0 +1,593 @@
+import { useState, useMemo } from 'react';
+import { MessageList, TypingIndicator } from './MessageList';
+import type { ThemePreviewProps, Message, Chat, PreviewThemeColors } from './types';
+import { hexToCSS, defaultPreviewTheme } from './types';
+
+/**
+ * Sample messages for the preview
+ */
+const sampleMessages: Message[] = [
+  {
+    id: '1',
+    text: 'Hey! Check out this new theme I made 🎨',
+    direction: 'incoming',
+    timestamp: new Date(Date.now() - 3600000),
+    senderName: 'Alex',
+  },
+  {
+    id: '2',
+    text: 'Wow, it looks amazing! Love the colors',
+    direction: 'outgoing',
+    timestamp: new Date(Date.now() - 3500000),
+    readStatus: 'read',
+  },
+  {
+    id: '3',
+    text: 'Thanks! I extracted them from a sunset photo',
+    direction: 'incoming',
+    timestamp: new Date(Date.now() - 3400000),
+    senderName: 'Alex',
+    replyTo: {
+      senderName: 'You',
+      text: 'Wow, it looks amazing! Love the colors',
+    },
+  },
+  {
+    id: '4',
+    text: 'That\'s so cool! Can you share the theme file?',
+    direction: 'outgoing',
+    timestamp: new Date(Date.now() - 3300000),
+    readStatus: 'read',
+  },
+  {
+    id: '5',
+    text: 'Sure! I\'ll send it right now',
+    direction: 'incoming',
+    timestamp: new Date(Date.now() - 60000),
+    senderName: 'Alex',
+  },
+  {
+    id: '6',
+    text: 'Perfect, thanks! 🙌',
+    direction: 'outgoing',
+    timestamp: new Date(Date.now() - 30000),
+    readStatus: 'delivered',
+  },
+];
+
+/**
+ * Sample chats for the sidebar
+ */
+const sampleChats: Chat[] = [
+  {
+    id: '1',
+    name: 'Alex',
+    lastMessage: 'Sure! I\'ll send it right now',
+    timestamp: new Date(Date.now() - 60000),
+    isOnline: true,
+    isActive: true,
+  },
+  {
+    id: '2',
+    name: 'Theme Creators',
+    lastMessage: 'Check out the new gradient themes!',
+    timestamp: new Date(Date.now() - 3600000),
+    unreadCount: 3,
+    avatarColor: '#4fad2d',
+  },
+  {
+    id: '3',
+    name: 'Sarah',
+    lastMessage: 'See you tomorrow!',
+    timestamp: new Date(Date.now() - 86400000),
+    avatarColor: '#d09306',
+  },
+  {
+    id: '4',
+    name: 'Design Team',
+    lastMessage: 'Mike: The mockups are ready',
+    timestamp: new Date(Date.now() - 172800000),
+    isMuted: true,
+    unreadCount: 12,
+    avatarColor: '#c03d33',
+  },
+];
+
+/**
+ * Title bar component
+ */
+function TitleBar({ theme }: { theme: PreviewThemeColors }) {
+  return (
+    <div
+      data-testid="title-bar"
+      className="flex items-center justify-between h-8 px-3"
+      style={{ backgroundColor: hexToCSS(theme.titleBgActive) }}
+    >
+      <div className="flex items-center gap-2">
+        <div className="w-3 h-3 rounded-full bg-red-500" />
+        <div className="w-3 h-3 rounded-full bg-yellow-500" />
+        <div className="w-3 h-3 rounded-full bg-green-500" />
+      </div>
+      <span
+        className="text-xs font-medium"
+        style={{ color: hexToCSS(theme.titleFgActive) }}
+      >
+        Telegram Desktop
+      </span>
+      <div className="w-12" />
+    </div>
+  );
+}
+
+/**
+ * Chat list item component
+ */
+function ChatListItem({
+  chat,
+  theme,
+  onClick,
+}: {
+  chat: Chat;
+  theme: PreviewThemeColors;
+  onClick?: () => void;
+}) {
+  const isActive = chat.isActive;
+  
+  const styles = useMemo(() => ({
+    backgroundColor: isActive
+      ? hexToCSS(theme.dialogsBgActive)
+      : hexToCSS(theme.dialogsBg),
+    nameColor: isActive
+      ? hexToCSS(theme.dialogsNameFgActive)
+      : hexToCSS(theme.dialogsNameFg),
+    textColor: isActive
+      ? hexToCSS(theme.dialogsTextFgActive)
+      : hexToCSS(theme.dialogsTextFg),
+    dateColor: isActive
+      ? hexToCSS(theme.dialogsDateFgActive)
+      : hexToCSS(theme.dialogsDateFg),
+    unreadBg: chat.isMuted
+      ? hexToCSS(theme.dialogsUnreadBgMuted)
+      : hexToCSS(theme.dialogsUnreadBg),
+    unreadFg: hexToCSS(theme.dialogsUnreadFg),
+  }), [theme, isActive, chat.isMuted]);
+  
+  const avatarColor = chat.avatarColor || theme.windowBgActive;
+  
+  return (
+    <div
+      data-testid="chat-list-item"
+      className={`
+        flex items-center gap-3 px-3 py-2 cursor-pointer
+        transition-colors duration-150
+      `}
+      style={{ backgroundColor: styles.backgroundColor }}
+      onClick={onClick}
+    >
+      {/* Avatar */}
+      <div
+        className="w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0 text-white font-medium"
+        style={{ backgroundColor: hexToCSS(avatarColor) }}
+      >
+        {chat.name.charAt(0).toUpperCase()}
+        {chat.isOnline && (
+          <div
+            className="absolute bottom-0 right-0 w-3 h-3 rounded-full border-2 border-white bg-green-500"
+          />
+        )}
+      </div>
+      
+      {/* Chat info */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between">
+          <span
+            className="font-medium truncate"
+            style={{ color: styles.nameColor }}
+          >
+            {chat.name}
+          </span>
+          <span
+            className="text-xs flex-shrink-0"
+            style={{ color: styles.dateColor }}
+          >
+            {formatChatTime(chat.timestamp)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between mt-0.5">
+          <span
+            className="text-sm truncate"
+            style={{ color: styles.textColor }}
+          >
+            {chat.lastMessage}
+          </span>
+          {chat.unreadCount && (
+            <span
+              className="ml-2 px-1.5 py-0.5 rounded-full text-xs font-medium flex-shrink-0"
+              style={{
+                backgroundColor: styles.unreadBg,
+                color: styles.unreadFg,
+              }}
+            >
+              {chat.unreadCount}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Formats timestamp for chat list
+ */
+function formatChatTime(date: Date): string {
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const days = Math.floor(diff / 86400000);
+  
+  if (days === 0) {
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }).toLowerCase();
+  }
+  
+  if (days === 1) {
+    return 'Yesterday';
+  }
+  
+  if (days < 7) {
+    return date.toLocaleDateString('en-US', { weekday: 'short' });
+  }
+  
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Chat header component
+ */
+function ChatHeader({
+  chatName,
+  isOnline,
+  theme,
+}: {
+  chatName: string;
+  isOnline?: boolean;
+  theme: PreviewThemeColors;
+}) {
+  return (
+    <div
+      data-testid="chat-header"
+      className="flex items-center justify-between px-4 py-3 border-b"
+      style={{
+        backgroundColor: hexToCSS(theme.windowBg),
+        borderColor: hexToCSS(theme.menuSeparatorFg),
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className="w-10 h-10 rounded-full flex items-center justify-center text-white font-medium"
+          style={{ backgroundColor: hexToCSS(theme.windowBgActive) }}
+        >
+          {chatName.charAt(0).toUpperCase()}
+        </div>
+        <div>
+          <div
+            className="font-medium"
+            style={{ color: hexToCSS(theme.windowFg) }}
+          >
+            {chatName}
+          </div>
+          <div
+            className="text-xs"
+            style={{
+              color: isOnline
+                ? hexToCSS(theme.windowBgActive)
+                : hexToCSS(theme.dialogsTextFg),
+            }}
+          >
+            {isOnline ? 'online' : 'last seen recently'}
+          </div>
+        </div>
+      </div>
+      
+      {/* Header icons */}
+      <div className="flex items-center gap-4">
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke={hexToCSS(theme.historyComposeIconFg)}
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke={hexToCSS(theme.historyComposeIconFg)}
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+          />
+        </svg>
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke={hexToCSS(theme.historyComposeIconFg)}
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compose area component
+ */
+function ComposeArea({ theme }: { theme: PreviewThemeColors }) {
+  return (
+    <div
+      data-testid="compose-area"
+      className="flex items-center gap-3 px-4 py-3 border-t"
+      style={{
+        backgroundColor: hexToCSS(theme.historyComposeAreaBg),
+        borderColor: hexToCSS(theme.menuSeparatorFg),
+      }}
+    >
+      {/* Attachment button */}
+      <button
+        className="flex-shrink-0 p-1 rounded-full transition-colors"
+        style={{ color: hexToCSS(theme.historyComposeIconFg) }}
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+          />
+        </svg>
+      </button>
+      
+      {/* Input field */}
+      <div
+        className="flex-1 px-4 py-2 rounded-full text-sm"
+        style={{
+          backgroundColor: hexToCSS(theme.windowBgOver),
+          color: hexToCSS(theme.historyComposeAreaFg),
+        }}
+      >
+        <span style={{ color: hexToCSS(theme.dialogsTextFg) }}>
+          Write a message...
+        </span>
+      </div>
+      
+      {/* Emoji button */}
+      <button
+        className="flex-shrink-0 p-1 rounded-full transition-colors"
+        style={{ color: hexToCSS(theme.historyComposeIconFg) }}
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </button>
+      
+      {/* Microphone button */}
+      <button
+        className="flex-shrink-0 p-1 rounded-full transition-colors"
+        style={{ color: hexToCSS(theme.historyComposeIconFg) }}
+      >
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Sidebar component
+ */
+function Sidebar({
+  chats,
+  theme,
+  onSelectChat,
+}: {
+  chats: Chat[];
+  theme: PreviewThemeColors;
+  onSelectChat?: (chatId: string) => void;
+}) {
+  return (
+    <div
+      data-testid="sidebar"
+      className="flex flex-col h-full border-r flex-shrink-0"
+      style={{
+        backgroundColor: hexToCSS(theme.dialogsBg),
+        borderColor: hexToCSS(theme.menuSeparatorFg),
+        width: '280px',
+      }}
+    >
+      {/* Search bar */}
+      <div
+        className="px-3 py-2 border-b"
+        style={{ borderColor: hexToCSS(theme.menuSeparatorFg) }}
+      >
+        <div
+          className="flex items-center gap-2 px-3 py-2 rounded-lg"
+          style={{ backgroundColor: hexToCSS(theme.windowBgOver) }}
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke={hexToCSS(theme.dialogsTextFg)}
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <span
+            className="text-sm"
+            style={{ color: hexToCSS(theme.dialogsTextFg) }}
+          >
+            Search
+          </span>
+        </div>
+      </div>
+      
+      {/* Chat list */}
+      <div className="flex-1 overflow-y-auto">
+        {chats.map((chat) => (
+          <ChatListItem
+            key={chat.id}
+            chat={chat}
+            theme={theme}
+            onClick={() => onSelectChat?.(chat.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ThemePreview component
+ * 
+ * A realistic preview of how a theme looks in Telegram Desktop.
+ * Includes sidebar with chat list, message area, and compose input.
+ * Updates in real-time when theme colors change.
+ */
+export function ThemePreview({
+  theme = defaultPreviewTheme,
+  className = '',
+  showSidebar = true,
+  responsive = true,
+}: ThemePreviewProps) {
+  const [selectedChat, setSelectedChat] = useState<string>('1');
+  const [showTyping, setShowTyping] = useState(false);
+  
+  // Get the active chat
+  const activeChat = useMemo(
+    () => sampleChats.find((c) => c.id === selectedChat) || sampleChats[0],
+    [selectedChat]
+  );
+  
+  // Update chats to mark selected as active
+  const chatsWithActive = useMemo(
+    () => sampleChats.map((chat) => ({
+      ...chat,
+      isActive: chat.id === selectedChat,
+    })),
+    [selectedChat]
+  );
+  
+  // Show typing indicator briefly when chat changes
+  const handleSelectChat = (chatId: string) => {
+    setSelectedChat(chatId);
+    setShowTyping(true);
+    setTimeout(() => setShowTyping(false), 2000);
+  };
+  
+  return (
+    <div
+      data-testid="theme-preview"
+      className={`
+        flex flex-col rounded-lg overflow-hidden shadow-xl
+        ${responsive ? 'w-full max-w-4xl' : ''}
+        ${className}
+      `}
+      style={{
+        backgroundColor: hexToCSS(theme.windowBg),
+        height: responsive ? 'auto' : '600px',
+        minHeight: '400px',
+      }}
+    >
+      {/* Title bar */}
+      <TitleBar theme={theme} />
+      
+      {/* Main content area */}
+      <div
+        className={`
+          flex flex-1 min-h-0
+          ${responsive ? 'flex-col md:flex-row' : 'flex-row'}
+        `}
+      >
+        {/* Sidebar */}
+        {showSidebar && (
+          <div className={responsive ? 'hidden md:block' : ''}>
+            <Sidebar
+              chats={chatsWithActive}
+              theme={theme}
+              onSelectChat={handleSelectChat}
+            />
+          </div>
+        )}
+        
+        {/* Chat area */}
+        <div className="flex flex-col flex-1 min-w-0">
+          {/* Chat header */}
+          <ChatHeader
+            chatName={activeChat.name}
+            isOnline={activeChat.isOnline}
+            theme={theme}
+          />
+          
+          {/* Message list */}
+          <MessageList
+            messages={sampleMessages}
+            theme={theme}
+            isGroupChat={false}
+          />
+          
+          {/* Typing indicator */}
+          {showTyping && (
+            <div className="px-3 pb-2">
+              <TypingIndicator
+                bgColor={theme.msgInBg}
+                dotColor={theme.dialogsTextFg}
+              />
+            </div>
+          )}
+          
+          {/* Compose area */}
+          <ComposeArea theme={theme} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ThemePreview;

--- a/src/components/preview/index.ts
+++ b/src/components/preview/index.ts
@@ -1,0 +1,19 @@
+// Preview component exports
+export { ChatBubble, default as ChatBubbleDefault } from './ChatBubble';
+export { MessageList, TypingIndicator, default as MessageListDefault } from './MessageList';
+export { ThemePreview, default as ThemePreviewDefault } from './ThemePreview';
+
+// Type exports
+export type {
+  PreviewThemeColors,
+  MessageDirection,
+  ReadStatus,
+  Message,
+  Chat,
+  ChatBubbleProps,
+  MessageListProps,
+  ThemePreviewProps,
+  ChatListItemProps,
+} from './types';
+
+export { defaultPreviewTheme, hexToCSS } from './types';

--- a/src/components/preview/types.ts
+++ b/src/components/preview/types.ts
@@ -1,0 +1,321 @@
+/**
+ * Types for the Telegram Theme Preview components
+ */
+
+/**
+ * Theme colors used for preview rendering
+ * Maps to Telegram Desktop theme properties
+ */
+export interface PreviewThemeColors {
+  // Window colors
+  windowBg: string;
+  windowFg: string;
+  windowBgOver: string;
+  windowFgOver: string;
+  windowBgActive: string;
+  windowFgActive: string;
+  
+  // Chat/History colors
+  historyPeer1NameFg: string;
+  historyPeer2NameFg: string;
+  historyPeer3NameFg: string;
+  historyPeer4NameFg: string;
+  
+  // Message bubbles
+  msgInBg: string;
+  msgInBgSelected: string;
+  msgOutBg: string;
+  msgOutBgSelected: string;
+  msgInShadow: string;
+  msgOutShadow: string;
+  
+  // Message text
+  historyTextInFg: string;
+  historyTextOutFg: string;
+  
+  // Timestamps and meta
+  msgInDateFg: string;
+  msgOutDateFg: string;
+  historyOutIconFg: string;
+  historyOutIconFgSelected: string;
+  
+  // Reply and forward
+  msgInReplyBarColor: string;
+  msgOutReplyBarColor: string;
+  msgInReplyBarSelColor: string;
+  msgOutReplyBarSelColor: string;
+  
+  // Service messages
+  msgServiceBg: string;
+  msgServiceFg: string;
+  
+  // Dialogs/sidebar
+  dialogsBg: string;
+  dialogsNameFg: string;
+  dialogsTextFg: string;
+  dialogsDateFg: string;
+  dialogsBgActive: string;
+  dialogsNameFgActive: string;
+  dialogsTextFgActive: string;
+  dialogsDateFgActive: string;
+  dialogsUnreadBg: string;
+  dialogsUnreadBgMuted: string;
+  dialogsUnreadFg: string;
+  
+  // Accent colors
+  activeButtonBg: string;
+  activeButtonFg: string;
+  activeButtonBgOver: string;
+  activeButtonBgRipple: string;
+  
+  // Input field
+  historyComposeAreaBg: string;
+  historyComposeAreaFg: string;
+  historyComposeIconFg: string;
+  historyComposeIconFgOver: string;
+  
+  // Scrollbar
+  scrollBg: string;
+  scrollBgOver: string;
+  scrollBarBg: string;
+  scrollBarBgOver: string;
+  
+  // Menu
+  menuBg: string;
+  menuBgOver: string;
+  menuIconFg: string;
+  menuFgDisabled: string;
+  menuSeparatorFg: string;
+  
+  // Tooltips
+  tooltipBg: string;
+  tooltipFg: string;
+  tooltipBorderFg: string;
+  
+  // Title bar
+  titleBg: string;
+  titleFg: string;
+  titleBgActive: string;
+  titleFgActive: string;
+  titleButtonBg: string;
+  titleButtonFg: string;
+  titleButtonBgOver: string;
+  titleButtonFgOver: string;
+  titleButtonBgActive: string;
+  titleButtonFgActive: string;
+  titleButtonCloseBg: string;
+  titleButtonCloseFg: string;
+  titleButtonCloseBgOver: string;
+  titleButtonCloseFgOver: string;
+}
+
+/**
+ * Message direction
+ */
+export type MessageDirection = 'incoming' | 'outgoing';
+
+/**
+ * Message read status
+ */
+export type ReadStatus = 'sent' | 'delivered' | 'read';
+
+/**
+ * Single message data
+ */
+export interface Message {
+  id: string;
+  text: string;
+  direction: MessageDirection;
+  timestamp: Date;
+  senderName?: string;
+  readStatus?: ReadStatus;
+  replyTo?: {
+    senderName: string;
+    text: string;
+  };
+  isService?: boolean;
+}
+
+/**
+ * Chat/Conversation data
+ */
+export interface Chat {
+  id: string;
+  name: string;
+  lastMessage: string;
+  timestamp: Date;
+  unreadCount?: number;
+  isOnline?: boolean;
+  isMuted?: boolean;
+  isActive?: boolean;
+  avatarColor?: string;
+}
+
+/**
+ * Props for ChatBubble component
+ */
+export interface ChatBubbleProps {
+  message: Message;
+  theme: PreviewThemeColors;
+  showSenderName?: boolean;
+  isGroupChat?: boolean;
+  className?: string;
+}
+
+/**
+ * Props for MessageList component
+ */
+export interface MessageListProps {
+  messages: Message[];
+  theme: PreviewThemeColors;
+  isGroupChat?: boolean;
+  className?: string;
+}
+
+/**
+ * Props for ThemePreview component
+ */
+export interface ThemePreviewProps {
+  theme: PreviewThemeColors;
+  className?: string;
+  showSidebar?: boolean;
+  responsive?: boolean;
+}
+
+/**
+ * Props for ChatListItem component
+ */
+export interface ChatListItemProps {
+  chat: Chat;
+  theme: PreviewThemeColors;
+  onClick?: () => void;
+  className?: string;
+}
+
+/**
+ * Default preview theme colors (light theme)
+ */
+export const defaultPreviewTheme: PreviewThemeColors = {
+  // Window
+  windowBg: '#ffffff',
+  windowFg: '#000000',
+  windowBgOver: '#f1f1f1',
+  windowFgOver: '#000000',
+  windowBgActive: '#40a7e3',
+  windowFgActive: '#ffffff',
+  
+  // History peer names
+  historyPeer1NameFg: '#c03d33',
+  historyPeer2NameFg: '#4fad2d',
+  historyPeer3NameFg: '#d09306',
+  historyPeer4NameFg: '#168acd',
+  
+  // Message bubbles
+  msgInBg: '#ffffff',
+  msgInBgSelected: '#c2dcf2',
+  msgOutBg: '#efffde',
+  msgOutBgSelected: '#b7dbdb',
+  msgInShadow: '#00000000',
+  msgOutShadow: '#00000000',
+  
+  // Message text
+  historyTextInFg: '#000000',
+  historyTextOutFg: '#000000',
+  
+  // Timestamps
+  msgInDateFg: '#a0acb6',
+  msgOutDateFg: '#6cc264',
+  historyOutIconFg: '#5dc452',
+  historyOutIconFgSelected: '#5dc452',
+  
+  // Reply
+  msgInReplyBarColor: '#40a7e3',
+  msgOutReplyBarColor: '#5dc452',
+  msgInReplyBarSelColor: '#40a7e3',
+  msgOutReplyBarSelColor: '#5dc452',
+  
+  // Service
+  msgServiceBg: '#7fc8e580',
+  msgServiceFg: '#ffffff',
+  
+  // Dialogs
+  dialogsBg: '#ffffff',
+  dialogsNameFg: '#212121',
+  dialogsTextFg: '#888888',
+  dialogsDateFg: '#a8a8a8',
+  dialogsBgActive: '#419fd9',
+  dialogsNameFgActive: '#ffffff',
+  dialogsTextFgActive: '#d4e7f5',
+  dialogsDateFgActive: '#d4e7f5',
+  dialogsUnreadBg: '#419fd9',
+  dialogsUnreadBgMuted: '#bbbbbb',
+  dialogsUnreadFg: '#ffffff',
+  
+  // Active button
+  activeButtonBg: '#40a7e3',
+  activeButtonFg: '#ffffff',
+  activeButtonBgOver: '#2095e4',
+  activeButtonBgRipple: '#1c8dd5',
+  
+  // Compose
+  historyComposeAreaBg: '#ffffff',
+  historyComposeAreaFg: '#000000',
+  historyComposeIconFg: '#999999',
+  historyComposeIconFgOver: '#40a7e3',
+  
+  // Scrollbar
+  scrollBg: '#00000000',
+  scrollBgOver: '#00000000',
+  scrollBarBg: '#c8c8c880',
+  scrollBarBgOver: '#9e9e9e80',
+  
+  // Menu
+  menuBg: '#ffffff',
+  menuBgOver: '#f1f1f1',
+  menuIconFg: '#40a7e3',
+  menuFgDisabled: '#a8a8a8',
+  menuSeparatorFg: '#e8e8e8',
+  
+  // Tooltips
+  tooltipBg: '#e5f0f6',
+  tooltipFg: '#547085',
+  tooltipBorderFg: '#c9d9e3',
+  
+  // Title bar
+  titleBg: '#ffffff',
+  titleFg: '#acacac',
+  titleBgActive: '#ffffff',
+  titleFgActive: '#3e3c3e',
+  titleButtonBg: '#ffffff00',
+  titleButtonFg: '#acacac',
+  titleButtonBgOver: '#e5e5e5',
+  titleButtonFgOver: '#9a9a9a',
+  titleButtonBgActive: '#e5e5e5',
+  titleButtonFgActive: '#9a9a9a',
+  titleButtonCloseBg: '#e5e5e5',
+  titleButtonCloseFg: '#d92626',
+  titleButtonCloseBgOver: '#e81123',
+  titleButtonCloseFgOver: '#ffffff',
+};
+
+/**
+ * Convert hex color to CSS-compatible format
+ */
+export function hexToCSS(hex: string): string {
+  // Remove # if present
+  const cleaned = hex.replace(/^#/, '');
+  
+  // Handle 6 or 8 character hex
+  if (cleaned.length === 6) {
+    return `#${cleaned}`;
+  } else if (cleaned.length === 8) {
+    // RRGGBBAA format - convert to CSS rgba
+    const r = parseInt(cleaned.slice(0, 2), 16);
+    const g = parseInt(cleaned.slice(2, 4), 16);
+    const b = parseInt(cleaned.slice(4, 6), 16);
+    const a = parseInt(cleaned.slice(6, 8), 16) / 255;
+    return `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`;
+  }
+  
+  return `#${cleaned}`;
+}


### PR DESCRIPTION
## Summary

Implements a realistic Telegram Desktop theme preview component that displays how themes look in the actual app interface.

## Issues
Closes #14 

## Changes

### New Files
- `src/components/preview/types.ts` - Type definitions and default theme colors
- `src/components/preview/ChatBubble.tsx` - Message bubble component
- `src/components/preview/ChatBubble.test.tsx` - 22 unit tests
- `src/components/preview/MessageList.tsx` - Message list with date separators
- `src/components/preview/MessageList.test.tsx` - 14 unit tests
- `src/components/preview/ThemePreview.tsx` - Full Telegram Desktop UI preview
- `src/components/preview/ThemePreview.test.tsx` - 30 unit tests
- `src/components/preview/index.ts` - Barrel exports

### Updated Files
- `src/components/index.ts` - Added preview exports

## Features

### ChatBubble Component
- Incoming/outgoing message styles with different backgrounds
- Read status indicators (sent, delivered, read)
- Reply previews with accent-colored bar
- Sender name coloring for group chats (4 peer colors)
- Service messages (date separators, system notifications)
- Timestamp display

### MessageList Component
- Scrollable message container
- Date separators ("Today", "Yesterday", weekday names)
- Typing indicator with animated dots
- Auto-scroll to bottom on new messages
- Groups messages by date

### ThemePreview Component
- Title bar with macOS-style window controls
- Sidebar with chat list:
  - Avatar with initials
  - Online status indicators
  - Unread count badges
  - Muted chat styling
  - Active chat highlighting
- Chat header with contact info and action icons
- Compose area with attachment/emoji/mic buttons
- Sample conversation demonstrating various message types

### Real-time Updates
- All colors update instantly when theme changes
- Uses CSS custom properties for efficient re-rendering
- Memoized style calculations for performance

### Responsive Design
- Sidebar hidden on mobile viewports
- Full-width chat area on smaller screens
- `responsive` prop to enable/disable responsive behavior

## Testing

- 66 new tests (22 ChatBubble + 14 MessageList + 30 ThemePreview)
- All 357 tests passing
- Lint passing
- Build successful

## Exports

```typescript
// Components
export { ChatBubble, MessageList, ThemePreview, TypingIndicator };

// Types
export type { PreviewThemeColors, Message, Chat, MessageDirection, ReadStatus };

// Utilities
export { defaultPreviewTheme, hexToCSS };